### PR TITLE
Add namespace support to type registry

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -15,12 +15,12 @@ var syncHash SynchronizedHash = NewHasher(fnv.New32a())
 var NIL Tuple = Tuple{}
 
 type TupleType struct {
-	Namspace     string // Tuple Namespace
-	Name         string // Tuple Name
-	NamspaceHash uint32
-	Hash         uint32
-	versions     [][]Field
-	fields       map[string]int
+	Namespace     string // Tuple Namespace
+	Name          string // Tuple Name
+	NamespaceHash uint32
+	Hash          uint32
+	versions      [][]Field
+	fields        map[string]int
 }
 
 type Version struct {
@@ -216,7 +216,7 @@ func NewTupleHeader(b TupleBuilder) (TupleHeader, error) {
 	return TupleHeader{
 		ProtocolVersion: 0,
 		TupleVersion:    tupleVersion,
-		NamespaceHash:   b.tupleType.NamspaceHash,
+		NamespaceHash:   b.tupleType.NamespaceHash,
 		Hash:            b.tupleType.Hash,
 		FieldCount:      totalFieldCount,
 		FieldSize:       fieldSize,

--- a/registry.go
+++ b/registry.go
@@ -84,7 +84,7 @@ func (r *Registry) typeSignature(namespace, typename string) (hash uint64) {
 func (r *Registry) typeSignatureHash(nhash, thash uint32) (hash uint64) {
 
 	// Combine hashes
-	hash = uint64(thash)
-	hash |= uint64(nhash) << 32
+	hash = uint64(thash) << 32
+	hash |= uint64(nhash)
 	return
 }

--- a/registry.go
+++ b/registry.go
@@ -6,20 +6,20 @@ import (
 )
 
 func NewRegistry() Registry {
-	return Registry{content: make(map[uint32]TupleType), hasher: NewHasher(fnv.New32a())}
+	return Registry{content: make(map[uint64]TupleType), hasher: NewHasher(fnv.New32a())}
 }
 
 type Registry struct {
-	content map[uint32]TupleType
+	content map[uint64]TupleType
 	hasher  SynchronizedHash
 	mutex   sync.Mutex
 }
 
 func (r *Registry) Contains(t TupleType) bool {
-	return r.ContainsHash(t.Hash)
+	return r.ContainsHash(r.typeSignature(t.Namespace, t.Name))
 }
 
-func (r *Registry) ContainsHash(hash uint32) bool {
+func (r *Registry) ContainsHash(hash uint64) bool {
 	// lock registry
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
@@ -28,15 +28,23 @@ func (r *Registry) ContainsHash(hash uint32) bool {
 	return exists
 }
 
-func (r *Registry) ContainsName(name string) bool {
-	return r.ContainsHash(r.hasher.Hash([]byte(name)))
+func (r *Registry) ContainsName(namespace, name string) bool {
+	return r.ContainsHash(r.typeSignature(namespace, name))
 }
 
-func (r *Registry) Get(hash uint32) (tupleType TupleType, exists bool) {
+func (r *Registry) Get(namespace, name string) (tupleType TupleType, exists bool) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	tupleType, exists = r.content[hash]
+	tupleType, exists = r.content[r.typeSignature(namespace, name)]
+	return
+}
+
+func (r *Registry) GetWithHash(namespace, name uint32) (tupleType TupleType, exists bool) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	tupleType, exists = r.content[r.typeSignatureHash(namespace, name)]
 	return
 }
 
@@ -44,8 +52,9 @@ func (r *Registry) Register(t TupleType) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	if _, exists := r.content[t.Hash]; !exists {
-		r.content[t.Hash] = t
+	hash := r.typeSignature(t.Namespace, t.Name)
+	if _, exists := r.content[hash]; !exists {
+		r.content[hash] = t
 	}
 }
 
@@ -53,11 +62,29 @@ func (r *Registry) Unregister(t TupleType) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	if _, exists := r.content[t.Hash]; exists {
-		delete(r.content, t.Hash)
+	hash := r.typeSignature(t.Namespace, t.Name)
+	if _, exists := r.content[hash]; exists {
+		delete(r.content, hash)
 	}
 }
 
 func (r *Registry) Size() int {
 	return len(r.content)
+}
+
+func (r *Registry) typeSignature(namespace, typename string) (hash uint64) {
+	// Calculate hashes
+	nhash := r.hasher.Hash([]byte(namespace))
+	thash := r.hasher.Hash([]byte(typename))
+
+	hash = r.typeSignatureHash(nhash, thash)
+	return
+}
+
+func (r *Registry) typeSignatureHash(nhash, thash uint32) (hash uint64) {
+
+	// Combine hashes
+	hash = uint64(thash)
+	hash |= uint64(nhash) << 32
+	return
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -86,18 +86,19 @@ func TestRegistryContainsTrue(t *testing.T) {
 
 	// add User type
 	reg.Register(User)
+	hash := reg.typeSignature(User.Namespace, User.Name)
 
 	// make sure it contains the User type
-	assert.Equal(t, User, reg.content[User.Hash])
+	assert.Equal(t, User, reg.content[hash])
 
 	// test contains function
 	assert.Equal(t, true, reg.Contains(User))
 
 	// test contains hash function
-	assert.Equal(t, true, reg.ContainsHash(User.Hash))
+	assert.Equal(t, true, reg.ContainsHash(hash))
 
 	// test contains name function
-	assert.Equal(t, true, reg.ContainsName(User.Name))
+	assert.Equal(t, true, reg.ContainsName(User.Namespace, User.Name))
 }
 
 func TestRegistryContainsFalse(t *testing.T) {
@@ -107,21 +108,22 @@ func TestRegistryContainsFalse(t *testing.T) {
 
 	// create type
 	User := createTestTupleType()
+	hash := reg.typeSignature(User.Namespace, User.Name)
 
 	// DO NOT add User type
 	// reg.Register(User)
 
 	// make sure it DOES NOT contains the User type
-	assert.Equal(t, TupleType{}, reg.content[User.Hash])
+	assert.Equal(t, TupleType{}, reg.content[hash])
 
 	// test contains function
 	assert.Equal(t, false, reg.Contains(User))
 
 	// test contains hash function
-	assert.Equal(t, false, reg.ContainsHash(User.Hash))
+	assert.Equal(t, false, reg.ContainsHash(hash))
 
 	// test contains name function
-	assert.Equal(t, false, reg.ContainsName(User.Name))
+	assert.Equal(t, false, reg.ContainsName(User.Namespace, User.Name))
 }
 
 func TestRegistryGetTrue(t *testing.T) {
@@ -136,7 +138,7 @@ func TestRegistryGetTrue(t *testing.T) {
 	reg.Register(User)
 
 	// make sure the registry contains the same User type
-	tupleType, exists := reg.Get(User.Hash)
+	tupleType, exists := reg.Get(User.Namespace, User.Name)
 	assert.Equal(t, User, tupleType)
 	assert.Equal(t, true, exists)
 }
@@ -153,7 +155,7 @@ func TestRegistryGetFalse(t *testing.T) {
 	// reg.Register(User)
 
 	// make sure the registry contains the same User type
-	tupleType, exists := reg.Get(User.Hash)
+	tupleType, exists := reg.Get(User.Namespace, User.Name)
 	assert.Equal(t, TupleType{}, tupleType)
 	assert.Equal(t, false, exists)
 }


### PR DESCRIPTION
Add namespace support to type registry

Changed registry to use uint64. (32 high bits are namespace, 32 low are type name). Added utility methods to registry.